### PR TITLE
Added search feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,14 @@ include_directories(${SYSTEMD_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${SYSTEMD_LIBRARIES})
 
 pkg_check_modules(NCURSES ncurses REQUIRED)
+pkg_check_modules(FORM form REQUIRED)
 
 include_directories(${NCURSES_INCLUDE_DIRS})
+include_directories(${FORM_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${NCURSES_LIBRARIES})
+set(LIBS ${LIBS} ${FORM_LIBRARIES})
+
+find_package(Boost REQUIRED COMPONENTS regex)
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/src)
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ dnf install chkservice
 Package dependencies:
   * libncurses5
   * libsystemd0 ( >= 222 )
+  * libboost-regex1.xx.y (tested with 1.58.0 & 1.65.1)
   
 Build dependencies:
   * pkg-config
   * libncurses5-dev
   * libsystemd-dev ( >= 222 )
+  * libboost-regex-dev
 
 ### Build
 

--- a/include/chk-ui.h
+++ b/include/chk-ui.h
@@ -22,6 +22,7 @@
 #define _CHKUI_H
 
 #include <curses.h>
+#include <form.h>
 #include "chk-ctl.h"
 
 typedef struct RECTANGLE {
@@ -43,6 +44,12 @@ class MainWindow {
     RECTANGLE *padding = new RECTANGLE();
     ChkCTL *ctl = new ChkCTL;
     std::vector<UnitItem *> units;
+
+    char *searchPattern;
+    // Defines whether instructions on how to go back to full services list
+    // must be displayed
+    bool showBackInstructions;
+
     int selected = 0;
     int start = 0;
     void createWindow();
@@ -53,6 +60,10 @@ class MainWindow {
     void movePageUp();
     void movePageDown();
     void drawUnits();
+
+    void filterUnits();
+    void clearFilter();
+
     void drawItem(UnitItem *unit, int y);
     void drawInfo();
     void toggleUnitState();
@@ -67,5 +78,6 @@ void stopCurses();
 void printInMiddle(WINDOW *win, int starty, int startx, int width,
     char *string, chtype color, char *sp);
 void aboutWindow(RECTANGLE *parent);
+void searchWindow(RECTANGLE *parent, char **searchText);
 
 #endif

--- a/include/chk.h
+++ b/include/chk.h
@@ -44,4 +44,8 @@
   License:\n\
     GPLv3 (c) Svetlana Linuxenko"
 
+
+#define SEARCH_FORM_INFO "\
+  Enter (sub)string or regexp to search for:\n\
+    (ESC/F10 to go back to services list)"
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,5 +9,6 @@ target_link_libraries(CHKUI ${LIBS} CHKSYSTEMD CHKCTL)
 
 add_executable(chkservice chkservice.cpp)
 target_link_libraries(chkservice ${LIBS} CHKSYSTEMD CHKCTL CHKUI)
+target_link_libraries(chkservice boost_regex)
 
 install(TARGETS chkservice RUNTIME DESTINATION bin)

--- a/src/chk-wutils.cpp
+++ b/src/chk-wutils.cpp
@@ -21,6 +21,11 @@
 #include "chk-ui.h"
 #include "chk.h"
 
+#include <string.h>
+#include <stdlib.h>
+
+#include <assert.h>
+
 void startCurses() {
   initscr();
   start_color();
@@ -88,6 +93,150 @@ void aboutWindow(RECTANGLE *parent) {
   wrefresh(aboutwin);
   getch();
   delwin(aboutwin);
+  clear();
+  refresh();
+}
+
+// Following function was retrieved from:
+// https://alan-mushi.github.io/2014/11/30/ncurses-forms.html
+
+/*
+ * This is useful because ncurses fill fields blanks with spaces.
+ */
+static char* trim_whitespaces(char *str)
+{
+  char *end;
+
+  // trim leading space
+  while(isspace(*str))
+    str++;
+
+  if(*str == 0) // all spaces?
+    return str;
+
+  // trim trailing space
+  end = str + strnlen(str, 128) - 1;
+
+  while(end > str && isspace(*end))
+    end--;
+
+  // write new null terminator
+  *(end+1) = '\0';
+
+  return str;
+}
+
+#define KEY_RETURN  10
+#define KEY_ESCAPE  27
+void searchWindow(RECTANGLE *parent, char **searchText) {
+  FORM *searchForm;
+  FIELD *searchField[2];
+  WINDOW *searchWinBody, *searchWin;
+  int done = 0;
+  int ch;
+
+  const int winH = 10;
+  const int winW = 60;
+
+  const int searchWinH = (parent->h / 2) - (winH / 2);
+  const int searchWinW = (parent->w / 2) - (winW / 2);
+
+  searchWinBody = newwin(winH, winW,
+      searchWinH,
+      searchWinW
+      );
+  assert(searchWinBody != NULL);
+
+  const int winFormNLines = winH - 4;
+  const int winFormNCols = winW - 2;
+  const int winFormY = 3;
+  const int winFormX = 1;
+
+  searchWin = derwin(searchWinBody,
+        winFormNLines, winFormNCols,
+        winFormY,
+        winFormX);
+  assert(searchWin != NULL);
+
+  wattron(searchWinBody, COLOR_PAIR(2));
+  mvwprintw(searchWinBody, 1, 2, SEARCH_FORM_INFO);
+  wattroff(searchWinBody, COLOR_PAIR(2));
+
+  const int searchFieldHeight = 1;
+  const int searchFieldWidth = winFormNCols - 2;
+  searchField[0] = new_field(searchFieldHeight, searchFieldWidth, 0, 0, 0, 0);
+  searchField[1] = NULL;
+  assert(searchField[0] != NULL);
+
+  set_field_fore(searchField[0], COLOR_PAIR(2));
+  set_field_back(searchField[0], A_UNDERLINE);
+
+  searchForm = new_form(searchField);
+  assert(searchForm != NULL);
+  set_form_win(searchForm, searchWin);
+  set_form_sub(searchForm, derwin(searchWin,
+        winFormNLines - 2, winFormNCols - 2,
+        1, 1));
+  post_form(searchForm);
+
+  /* show cursor */
+  curs_set(true);
+
+  refresh();
+  wrefresh(searchWinBody);
+  wrefresh(searchWin);
+
+  while(!done)
+  {
+    ch = getch();
+    switch(ch) {
+      case KEY_RETURN:
+        form_driver(searchForm, REQ_VALIDATION);
+        *searchText = strdup(trim_whitespaces(field_buffer(searchField[0], 0)));
+        done = 1;
+        break;
+
+      case KEY_ESCAPE:
+      case KEY_F(10):
+        done = 1;
+        break;
+
+      case KEY_BACKSPACE:
+        form_driver(searchForm, REQ_DEL_PREV);
+        break;
+
+      case KEY_HOME:
+        form_driver(searchForm, REQ_BEG_LINE);
+        break;
+
+      case KEY_END:
+        form_driver(searchForm, REQ_END_LINE);
+        break;
+
+      case KEY_LEFT:
+        form_driver(searchForm, REQ_PREV_CHAR);
+        break;
+
+      case KEY_RIGHT:
+        form_driver(searchForm, REQ_NEXT_CHAR);
+        break;
+
+      default:
+        form_driver(searchForm, ch);
+        break;
+    }
+
+    wrefresh(searchWin);
+  }
+
+
+  unpost_form(searchForm);
+  free_form(searchForm);
+  free_field(searchField[0]);
+  delwin(searchWin);
+  delwin(searchWinBody);
+
+  curs_set(false);
   clear();
   refresh();
 }


### PR DESCRIPTION
Deisgn decision:
- Instead of maintaining a separate "search results" units list, the main units list becomes the "search results" one. This means that to go back to the "full" list, user has to press 'r'.

This design is debatable. A separate "search results" list can be added and maintained, but it means significant changes of the current chkservice implementation.

Signed-off-by: Gilles Talis <gilles.talis@gmail.com>